### PR TITLE
Bump StackExchange.Redis from 2.0.505 to 2.0.601

### DIFF
--- a/BackendForFrontend/BackendForFrontend.csproj
+++ b/BackendForFrontend/BackendForFrontend.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.0.513" />
+    <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
   </ItemGroup>
 
 </Project>

--- a/BackendForFrontend/Startup.cs
+++ b/BackendForFrontend/Startup.cs
@@ -74,7 +74,7 @@ namespace BackendForFrontend
 
                 if (message != RedisValue.Null)
                 {
-                    await notificationHub.Clients.All.SendAsync("NewNotification", message);
+                    await notificationHub.Clients.All.SendAsync("NewNotification", message.ToString());
                     Console.WriteLine($"Forwarded message: { message }");
                 }
             });

--- a/NotificationProducer/NotificationProducer.csproj
+++ b/NotificationProducer/NotificationProducer.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.0.505" />
+    <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Somewhere along the way the implicit operator behavior changed for RedisValue requiring an explicit call for .ToString() otherwise a RedisValue object and its properties would be sent over the wire.